### PR TITLE
Add GPU support;Use resource limits for resource detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pyc
 *.pyo
 .pytest_cache/
+venv/
+.knoc/
+

--- a/handles.py
+++ b/handles.py
@@ -1022,15 +1022,16 @@ def produce_htcondor_singularity_script(
 
     requested_cpus = 0
     requested_memory = 0
+    requested_gpus = 0
     for c in containers:
-        if "resources" in c.keys():
-            if "requests" in c["resources"].keys():
-                if "cpu" in c["resources"]["requests"].keys():
-                    requested_cpus += parse_cpu(c["resources"]["requests"]["cpu"])
-                if "memory" in c["resources"]["requests"].keys():
-                    requested_memory += parse_string_with_suffix(
-                        c["resources"]["requests"]["memory"]
-                    )
+        if "resources" in c:
+            limits = c["resources"].get("limits", {})
+            if "cpu" in limits:
+                requested_cpus += parse_cpu(limits["cpu"])
+            if "memory" in limits:
+                requested_memory += parse_string_with_suffix(limits["memory"])
+            if "nvidia.com/gpu" in limits:
+                requested_gpus += int(limits["nvidia.com/gpu"])
     if requested_cpus == 0:
         requested_cpus = 1
     if requested_memory == 0:
@@ -1198,6 +1199,7 @@ Error      = err/mm_mul.err.$(Cluster).$(Process)
 should_transfer_files = YES
 RequestCpus = {requested_cpus}
 RequestMemory = {requested_memory}
+RequestGpus = {requested_gpus}
 
 # Retry if the job is held due to the permission error (Code 12, Subcode 13)
 periodic_release = (HoldReasonCode == 12 && HoldReasonSubCode == 13)
@@ -1452,6 +1454,9 @@ def SubmitHandler():
             singularity_options = metadata.get("annotations", {}).get(
                 "slurm-job.vk.io/singularity-options", ""
             )
+            if "nvidia.com/gpu" in container.get("resources", {}).get("limits", {}):
+                if "--nv" not in singularity_options:
+                    singularity_options = ("--nv " + singularity_options).strip()
             pre_exec = metadata.get("annotations", {}).get(
                 "slurm-job.vk.io/pre-exec", ""
             )
@@ -1559,6 +1564,9 @@ def SubmitHandler():
             singularity_options = metadata.get("annotations", {}).get(
                 "slurm-job.vk.io/singularity-options", ""
             )
+            if "nvidia.com/gpu" in container.get("resources", {}).get("limits", {}):
+                if "--nv" not in singularity_options:
+                    singularity_options = ("--nv " + singularity_options).strip()
 
             # flags = metadata.get("annotations", {}).get(
             #     "slurm-job.vk.io/flags", "")

--- a/tests/gpu_k8s.yaml
+++ b/tests/gpu_k8s.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test-pod-gpu
+spec:
+    restartPolicy: OnFailure
+    containers:
+        - image: docker://nvidia/cuda:12.6.3-base-ubuntu24.04
+          command:
+              - /bin/bash
+              - -c
+              - |
+                echo "=== GPU Test Start ==="
+                nvidia-smi -L
+                echo "Assigned GPUs: $CUDA_VISIBLE_DEVICES"
+                echo "=== GPU Test End ==="
+          imagePullPolicy: Always
+          name: gpu-test
+          resources:
+              limits:
+                  memory: "512M"
+                  cpu: "1"
+                  nvidia.com/gpu: "2"
+    dnsPolicy: ClusterFirst
+    nodeSelector:
+        kubernetes.io/hostname: interlink-htcondor
+    tolerations:
+        - key: virtual-node.interlink/no-schedule
+          operator: Exists


### PR DESCRIPTION
## Summary

This PR makes two changes:

1. **Switches resource detection from `requests` to `limits`** for CPU, memory, and GPU. 

2. **Adds automatic GPU passthrough.** When `nvidia.com/gpu` is present in `limits`, the plugin automatically injects the `--nv` flag into Singularity options to enable NVIDIA runtime support inside the container.

A test manifest (`tests/gpu_k8s.yaml`) is included to validate GPU end-to-end via `nvidia-smi`.

## Changes

- **Plugin:** Read CPU, memory, and GPU from `resources.limits` instead of `resources.requests`.
- **Plugin:** Auto-inject `--nv` into Singularity options when `nvidia.com/gpu` is detected.
- **Test:** Add `tests/gpu_k8s.yaml` — runs `nvidia-smi` via the Interlink HTCondor virtual node.

## Testing

```bash
kubectl apply -f tests/gpu_k8s.yaml
# Expected: nvidia-smi lists GPUs, CUDA_VISIBLE_DEVICES=0,1

