### PR TITLE
normalize condor job submission from bytes to MB

### DIFF
--- a/handles.py
+++ b/handles.py
@@ -460,11 +460,14 @@ def parse_string_with_suffix(value_str):
         "Gi": 1024,
     }
 
-    match = re.match(r"(\d+)([a-zA-Z]+)", value_str)
+    value_str = str(value_str).strip()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([a-zA-Z]+)?", value_str)
     if match:
         numeric_part = match.group(1)
         suffix = match.group(2)
-        if suffix in suffixes:
+        if suffix is None:
+            return max(1, int(math.ceil(float(numeric_part) / 1024**2)))
+        elif suffix in suffixes:
             numeric_value = int(float(numeric_part) * suffixes[suffix])
             return numeric_value
         else:


### PR DESCRIPTION
k8s submits memory as raw bytes, condor is expecting MB. A worker pod with a 4Gi limit comes through as 4294967296, the plugin's parser only handled suffixed values like 4Gi or 512M so bare bytes fell back to 1 MB and the job got submitted with RequestMemory = 1. Condor then holds the job as soon as it tries to use real memory.