### PR TITLE
New Feature: Allow ImageOverrides for Dask Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ CommandPrefix: ""            # Optional shell prefix prepended to every job comm
                              # e.g. "source /cvmfs/cms.cern.ch/cmsset_default.sh;"
 ExportPodData: true          # Mount ConfigMaps and Secrets into the Singularity job
 DataRootFolder: ".interlink/" # Directory used to store job scripts and tracking files
+ImageOverrides:              # Optional worker-side image substitutions
+  "registry.example/image:tag": "/shared/images/image.sif"
 ```
+
+Image overrides are applied only when the plugin builds Singularity commands, allowing
+Kubernetes to keep a valid registry image while HTCondor workers use a prebuilt SIF.
 
 Create the directories expected by HTCondor and the plugin:
 

--- a/SidecarConfig.yaml
+++ b/SidecarConfig.yaml
@@ -1,3 +1,4 @@
 CommandPrefix: ""
 ExportPodData: true
 DataRootFolder: ".knoc/"
+ImageOverrides: {}

--- a/handles.py
+++ b/handles.py
@@ -484,6 +484,32 @@ _LIFECYCLE_HOOK_TIMEOUT_SECONDS = 30
 _RE_TMP_BIND = re.compile(r"([^,:\s]+):/tmp(?::|,|\s|$)")
 
 
+def _resolve_image(image):
+    """Apply a configured image override and return a Singularity image URI."""
+    overrides = InterLinkConfigInst.get("ImageOverrides", {}) or {}
+    if not isinstance(overrides, dict):
+        logging.warning("ImageOverrides must be a mapping; ignoring configured value")
+        overrides = {}
+    candidates = [image]
+    if image.startswith("docker://"):
+        candidates.append(image.removeprefix("docker://"))
+    else:
+        candidates.append("docker://" + image)
+
+    for candidate in candidates:
+        if candidate in overrides:
+            resolved = overrides[candidate]
+            if not isinstance(resolved, str) or not resolved:
+                logging.warning("Ignoring invalid image override for %s", candidate)
+                continue
+            logging.info("Using image override for %s: %s", image, resolved)
+            return resolved
+
+    if image.startswith("/") or image.startswith("docker://"):
+        return image
+    return "docker://" + image
+
+
 def _find_tmp_bind_in_tokens(cmd_tokens):
     """Scan a list of singularity command tokens for a --bind spec with /tmp.
 
@@ -501,7 +527,7 @@ def _find_tmp_bind_in_tokens(cmd_tokens):
 def _find_image_in_tokens(cmd_tokens):
     """Return the first token that looks like a container image, or empty string."""
     for tok in cmd_tokens:
-        if tok.startswith("docker://") or tok.startswith("/cvmfs"):
+        if tok.startswith("docker://") or tok.startswith("/"):
             return tok
     return ""
 
@@ -516,7 +542,7 @@ def _inject_hook_tmp_into_cmd(cmd_tokens):
     """
     bind_val = '"${workingPath}/hook-tmp:/tmp"'
     for i, tok in enumerate(cmd_tokens):
-        if tok.startswith("docker://") or tok.startswith("/cvmfs"):
+        if tok.startswith("docker://") or tok.startswith("/"):
             new = list(cmd_tokens)
             new.insert(i, bind_val)
             new.insert(i, "--bind")
@@ -692,9 +718,7 @@ def generate_prestop_trap(containers, metadata):
         hook = _translate_lifecycle_hook(prestop)
         if hook is None:
             continue
-        image = container.get("image", "")
-        if not (image.startswith("/cvmfs") or image.startswith("docker://")):
-            image = "docker://" + image
+        image = _resolve_image(container.get("image", ""))
         entries.append({"name": container["name"], "hook": hook, "image": image})
 
     if not entries:
@@ -807,9 +831,7 @@ def prepare_probes(container, metadata):
     if not readiness and not liveness and not startup:
         return "", ""
 
-    image = container.get("image", "")
-    if not (image.startswith("/cvmfs") or image.startswith("docker://")):
-        image = "docker://" + image
+    image = _resolve_image(container.get("image", ""))
     opts = singularity_options.split() if singularity_options else []
 
     probe_script = generate_probe_script(
@@ -1511,12 +1533,7 @@ def SubmitHandler():
                 container, metadata, container_standalone
             )
             env_flags = ["--env-file", f"./{env_file_name}"] if env_file_name else []
-            if container["image"].startswith("/cvmfs") or container["image"].startswith(
-                "docker://"
-            ):
-                image = container["image"]
-            else:
-                image = "docker://" + container["image"]
+            image = _resolve_image(container["image"])
             for mount in mounts[-1].split(","):
                 if "/cvmfs" not in mount:
                     mount_src = mount.split(":")[0]
@@ -1638,12 +1655,7 @@ def SubmitHandler():
             #        logging.warning(
             #            "image-uri not specified for path in remote filesystem"
             #        )
-            if container["image"].startswith("/cvmfs") or container["image"].startswith(
-                "docker://"
-            ):
-                image = container["image"]
-            else:
-                image = "docker://" + container["image"]
+            image = _resolve_image(container["image"])
             # image = container["image"]
             logging.info("Appending all commands together...")
             for mount in mounts[-1].split(","):

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -884,7 +884,9 @@ class TestGeneratePreStopTrap:
 class TestPreStopTrapInScript:
     """Integration tests: preStop trap is injected into the generated script."""
 
-    def _container_with_prestop(self, name="c1", image="docker://busybox:latest", cmd=None):
+    def _container_with_prestop(
+        self, name="c1", image="docker://busybox:latest", cmd=None
+    ):
         if cmd is None:
             cmd = ["/bin/sh", "-c", "cleanup"]
         return {
@@ -991,7 +993,14 @@ class TestPostStartHelpers:
         assert handles._find_tmp_bind_in_tokens(tokens) == "/host/tmp"
 
     def test_find_tmp_bind_in_comma_spec(self):
-        tokens = ["singularity", "exec", "--bind", "/a:/b,/h/t:/tmp", "docker://img", "sh"]
+        tokens = [
+            "singularity",
+            "exec",
+            "--bind",
+            "/a:/b,/h/t:/tmp",
+            "docker://img",
+            "sh",
+        ]
         assert handles._find_tmp_bind_in_tokens(tokens) == "/h/t"
 
     def test_find_image_docker_prefix(self):
@@ -1105,7 +1114,9 @@ class TestPostStartInScript:
     def _poststart_hooks(self, container):
         lifecycle = container.get("lifecycle") or {}
         ps = lifecycle.get("postStart")
-        return {container["name"]: handles._translate_lifecycle_hook(ps) if ps else None}
+        return {
+            container["name"]: handles._translate_lifecycle_hook(ps) if ps else None
+        }
 
     def test_no_poststart_when_not_defined(self):
         container = _container("c1", "docker://busybox:latest")

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -823,9 +823,7 @@ class TestGeneratePreStopTrap:
             {
                 "name": "c1",
                 "image": "busybox:latest",
-                "lifecycle": {
-                    "preStop": {"exec": {"command": ["true"]}}
-                },
+                "lifecycle": {"preStop": {"exec": {"command": ["true"]}}},
             }
         ]
         result = handles.generate_prestop_trap(containers, self._base_metadata())
@@ -897,9 +895,7 @@ class TestPreStopTrapInScript:
 
     def test_trap_in_script_when_prestop_defined(self):
         container = self._container_with_prestop()
-        prestop_trap = handles.generate_prestop_trap(
-            [container], _fake_metadata()
-        )
+        prestop_trap = handles.generate_prestop_trap([container], _fake_metadata())
         script = _make_script(
             [container],
             [("c1", ["singularity", "exec", "docker://busybox:latest", "sh"])],

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -176,6 +176,44 @@ class TestPrepareProbesImageHandling:
         probe_script, _ = prepare_probes(container, _BASE_METADATA)
         assert "docker://" not in probe_script
 
+    def test_configured_image_override(self, monkeypatch):
+        source = "registry.example/image:tag"
+        target = "/shared/images/image.sif"
+        monkeypatch.setitem(
+            handles.InterLinkConfigInst, "ImageOverrides", {source: target}
+        )
+        container = _container(
+            image=source,
+            livenessProbe={"httpGet": {"port": 8080}},
+        )
+        probe_script, _ = prepare_probes(container, _BASE_METADATA)
+        assert f'"{target}"' in probe_script
+        assert source not in probe_script
+
+
+class TestResolveImage:
+    def test_plain_image_gets_docker_prefix(self, monkeypatch):
+        monkeypatch.setitem(handles.InterLinkConfigInst, "ImageOverrides", {})
+        assert handles._resolve_image("busybox:latest") == "docker://busybox:latest"
+
+    def test_absolute_image_is_unchanged(self, monkeypatch):
+        monkeypatch.setitem(handles.InterLinkConfigInst, "ImageOverrides", {})
+        image = "/shared/images/busybox.sif"
+        assert handles._resolve_image(image) == image
+
+    def test_docker_prefixed_source_matches_plain_override(self, monkeypatch):
+        target = "/shared/images/busybox.sif"
+        monkeypatch.setitem(
+            handles.InterLinkConfigInst,
+            "ImageOverrides",
+            {"busybox:latest": target},
+        )
+        assert handles._resolve_image("docker://busybox:latest") == target
+
+    def test_invalid_override_config_is_ignored(self, monkeypatch):
+        monkeypatch.setitem(handles.InterLinkConfigInst, "ImageOverrides", [])
+        assert handles._resolve_image("busybox:latest") == "docker://busybox:latest"
+
 
 class TestPrepareProbesAnnotations:
     def test_singularity_options_from_annotation(self):


### PR DESCRIPTION
Every Condor worker was downloading the same large Docker image and converting it into a Singularity SIF before Dask could start. The logs would sit at:

`INFO: Creating SIF file...`

After running the conversion command

`singularity exec \
  docker://hub.opensciencegrid.org/coffea-casa/cc-dask-alma9:2025.10.10 \
  /bin/sh -c '. ./dask-worker_env.env && exec "$@"' \
  sh dask-worker tls://dask-<cluster-id>.cmsaf-dev:8786`


This ran for roughly 5 minutes before the worker failed to register with the scheduler, we added image overrides to the HTCondor plugin so that condor workers can map to the prebuilt sif on our target node

that change allows the config to have an image override section

/home/cmsuser/cms-jovyan/interlink-htcondor-plugin/SidecarConfig.yaml added `


```
ImageOverrides:
  "hub.opensciencegrid.org/coffea-casa/cc-dask-alma9:2025.10.10": "/var/cache/singularity-interlink/images/cc-dask-alma9-2025.10.10.sif"

```


Kubernetes can still use the normal Docker image for the scheduler, while Condor workers map that image to a prebuilt SIF cached on the target node. Workers can now start the cached image directly instead of downloading and converting it every time.