### PR TITLE
fix: generate mesh-aware Dask worker commands

### DIFF
--- a/handles.py
+++ b/handles.py
@@ -139,8 +139,34 @@ def _shell_single_quote(val):
     return "'" + str(val).replace("'", "'\"'\"'") + "'"
 
 
-def _wrap_command_with_env(command_tokens, env_file_name):
+_COMMAND_ENV_REF = re.compile(r"\$\(([A-Za-z_][A-Za-z0-9_]*)\)")
+
+
+def _expand_command_env(command_tokens, container):
+    """Expand Kubernetes-style ``$(VAR)`` references in command arguments."""
+    env = {
+        item["name"]: item.get("value") or ""
+        for item in container.get("env", [])
+        if "name" in item and item.get("value") is not None
+    }
+    expanded = []
+    for token in command_tokens:
+        matched = _COMMAND_ENV_REF.search(token)
+        if not matched:
+            expanded.append(token)
+            continue
+
+        value = _COMMAND_ENV_REF.sub(
+            lambda match: env.get(match.group(1), match.group(0)), token
+        )
+        expanded.append(shlex.quote(value))
+    return expanded
+
+
+def _wrap_command_with_env(command_tokens, env_file_name, container=None):
     """Source the generated env file inside the container, then exec the command."""
+    if container is not None:
+        command_tokens = _expand_command_env(command_tokens, container)
     if not env_file_name:
         return command_tokens
     return [
@@ -947,6 +973,18 @@ def _clean_command_tokens(tokens):
     return line.strip()
 
 
+def _add_mesh_dask_host(tokens, mesh_pre_exec):
+    """Bind Dask workers to the address configured on the mesh interface."""
+    if "dask-worker" not in tokens or "--host" in tokens:
+        return tokens
+    match = re.search(r"ip addr add ([0-9a-fA-F:.]+)/\d+ dev", mesh_pre_exec)
+    if not match:
+        return tokens
+    result = list(tokens)
+    result.extend(["--host", match.group(1)])
+    return result
+
+
 def produce_htcondor_singularity_script(
     containers,
     metadata,
@@ -1162,6 +1200,8 @@ def produce_htcondor_singularity_script(
 
             _mesh_wrapped = False
             for ctn_name, cmd_tokens in container_commands:
+                if mesh_pre_exec and not _mesh_wrapped:
+                    cmd_tokens = _add_mesh_dask_host(cmd_tokens, mesh_pre_exec)
                 hook = poststart_hooks.get(ctn_name)
                 if hook:
                     existing_tmp = _find_tmp_bind_in_tokens(cmd_tokens)
@@ -1546,7 +1586,7 @@ def SubmitHandler():
                 local_mounts = [""]
             if "command" in container and "args" in container:
                 container_entrypoint = _wrap_command_with_env(
-                    container["command"] + container["args"], env_file_name
+                    container["command"] + container["args"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]
@@ -1558,7 +1598,7 @@ def SubmitHandler():
                 )
             elif "command" in container:
                 container_entrypoint = _wrap_command_with_env(
-                    container["command"], env_file_name
+                    container["command"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]
@@ -1570,7 +1610,7 @@ def SubmitHandler():
                 )
             elif "args" in container:
                 container_entrypoint = _wrap_command_with_env(
-                    container["args"], env_file_name
+                    container["args"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]
@@ -1680,7 +1720,7 @@ def SubmitHandler():
 
             if "command" in container.keys() and "args" in container.keys():
                 container_entrypoint = _wrap_command_with_env(
-                    container["command"] + container["args"], env_file_name
+                    container["command"] + container["args"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]
@@ -1692,7 +1732,7 @@ def SubmitHandler():
                 )
             elif "command" in container.keys():
                 container_entrypoint = _wrap_command_with_env(
-                    container["command"], env_file_name
+                    container["command"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]
@@ -1704,7 +1744,7 @@ def SubmitHandler():
                 )
             elif "args" in container.keys():
                 container_entrypoint = _wrap_command_with_env(
-                    container["args"], env_file_name
+                    container["args"], env_file_name, container
                 )
                 singularity_command = (
                     [pre_exec]

--- a/handles.py
+++ b/handles.py
@@ -973,15 +973,35 @@ def _clean_command_tokens(tokens):
     return line.strip()
 
 
-def _add_mesh_dask_host(tokens, mesh_pre_exec):
-    """Bind Dask workers to the address configured on the mesh interface."""
-    if "dask-worker" not in tokens or "--host" in tokens:
+def _configure_mesh_dask_worker(tokens, mesh_pre_exec):
+    """Configure a Dask worker to listen on and advertise its mesh endpoints."""
+    if "dask-worker" not in tokens:
         return tokens
-    match = re.search(r"ip addr add ([0-9a-fA-F:.]+)/\d+ dev", mesh_pre_exec)
-    if not match:
+
+    host_match = re.search(r"ip addr add ([0-9a-fA-F:.]+)/\d+ dev", mesh_pre_exec)
+    if not host_match:
         return tokens
+
     result = list(tokens)
-    result.extend(["--host", match.group(1)])
+    if "--host" not in result:
+        result.extend(["--host", host_match.group(1)])
+
+    contact_match = re.search(
+        r'export INTERLINK_MESH_CONTACT_HOST="([^"]+)"', mesh_pre_exec
+    )
+    if not contact_match:
+        return result
+
+    if "--worker-port" in result:
+        port_index = result.index("--worker-port") + 1
+        worker_port = result[port_index] if port_index < len(result) else "8788"
+    else:
+        worker_port = "8788"
+        result.extend(["--worker-port", worker_port])
+
+    if "--contact-address" not in result:
+        contact_address = f"tls://{contact_match.group(1)}:{worker_port}"
+        result.extend(["--contact-address", contact_address])
     return result
 
 
@@ -1201,7 +1221,7 @@ def produce_htcondor_singularity_script(
             _mesh_wrapped = False
             for ctn_name, cmd_tokens in container_commands:
                 if mesh_pre_exec and not _mesh_wrapped:
-                    cmd_tokens = _add_mesh_dask_host(cmd_tokens, mesh_pre_exec)
+                    cmd_tokens = _configure_mesh_dask_worker(cmd_tokens, mesh_pre_exec)
                 hook = poststart_hooks.get(ctn_name)
                 if hook:
                     existing_tmp = _find_tmp_bind_in_tokens(cmd_tokens)

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -581,9 +581,7 @@ class TestCleanCommandTokens:
 
 class TestExpandCommandEnv:
     def test_expands_kubernetes_env_reference(self):
-        container = {
-            "env": [{"name": "DASK_GATEWAY_WORKER_NAME", "value": "worker-1"}]
-        }
+        container = {"env": [{"name": "DASK_GATEWAY_WORKER_NAME", "value": "worker-1"}]}
         result = handles._expand_command_env(
             ["--name", "$(DASK_GATEWAY_WORKER_NAME)"], container
         )
@@ -825,9 +823,7 @@ class TestGeneratePreStopTrap:
             {
                 "name": "c1",
                 "image": "busybox:latest",
-                "lifecycle": {
-                    "preStop": {"exec": {"command": ["true"]}}
-                },
+                "lifecycle": {"preStop": {"exec": {"command": ["true"]}}},
             }
         ]
         result = handles.generate_prestop_trap(containers, self._base_metadata())
@@ -899,9 +895,7 @@ class TestPreStopTrapInScript:
 
     def test_trap_in_script_when_prestop_defined(self):
         container = self._container_with_prestop()
-        prestop_trap = handles.generate_prestop_trap(
-            [container], _fake_metadata()
-        )
+        prestop_trap = handles.generate_prestop_trap([container], _fake_metadata())
         script = _make_script(
             [container],
             [("c1", ["singularity", "exec", "docker://busybox:latest", "sh"])],

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -579,6 +579,46 @@ class TestCleanCommandTokens:
         assert '("", 8080)' in result
 
 
+class TestExpandCommandEnv:
+    def test_expands_kubernetes_env_reference(self):
+        container = {
+            "env": [{"name": "DASK_GATEWAY_WORKER_NAME", "value": "worker-1"}]
+        }
+        result = handles._expand_command_env(
+            ["--name", "$(DASK_GATEWAY_WORKER_NAME)"], container
+        )
+        assert result == ["--name", "worker-1"]
+
+    def test_quotes_expanded_value_with_spaces(self):
+        container = {"env": [{"name": "WORKER_NAME", "value": "worker one"}]}
+        result = handles._expand_command_env(["$(WORKER_NAME)"], container)
+        assert result == ["'worker one'"]
+
+    def test_quotes_unresolved_reference(self):
+        result = handles._expand_command_env(["$(UNKNOWN)"], {"env": []})
+        assert result == ["'$(UNKNOWN)'"]
+
+
+class TestAddMeshDaskHost:
+    def test_adds_mesh_interface_address(self):
+        tokens = ["dask-worker", "tls://scheduler:8786", "--nthreads", "1"]
+        mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
+        assert handles._add_mesh_dask_host(tokens, mesh) == tokens + [
+            "--host",
+            "10.7.0.2",
+        ]
+
+    def test_preserves_explicit_host(self):
+        tokens = ["dask-worker", "tls://scheduler:8786", "--host", "10.8.0.2"]
+        mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
+        assert handles._add_mesh_dask_host(tokens, mesh) == tokens
+
+    def test_ignores_non_dask_commands(self):
+        tokens = ["python", "worker.py"]
+        mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
+        assert handles._add_mesh_dask_host(tokens, mesh) == tokens
+
+
 class TestPrepareEnvFile:
     def test_prepare_env_file_writes_export_lines(self, tmp_path, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -886,7 +886,9 @@ class TestGeneratePreStopTrap:
 class TestPreStopTrapInScript:
     """Integration tests: preStop trap is injected into the generated script."""
 
-    def _container_with_prestop(self, name="c1", image="docker://busybox:latest", cmd=None):
+    def _container_with_prestop(
+        self, name="c1", image="docker://busybox:latest", cmd=None
+    ):
         if cmd is None:
             cmd = ["/bin/sh", "-c", "cleanup"]
         return {
@@ -993,7 +995,14 @@ class TestPostStartHelpers:
         assert handles._find_tmp_bind_in_tokens(tokens) == "/host/tmp"
 
     def test_find_tmp_bind_in_comma_spec(self):
-        tokens = ["singularity", "exec", "--bind", "/a:/b,/h/t:/tmp", "docker://img", "sh"]
+        tokens = [
+            "singularity",
+            "exec",
+            "--bind",
+            "/a:/b,/h/t:/tmp",
+            "docker://img",
+            "sh",
+        ]
         assert handles._find_tmp_bind_in_tokens(tokens) == "/h/t"
 
     def test_find_image_docker_prefix(self):
@@ -1107,7 +1116,9 @@ class TestPostStartInScript:
     def _poststart_hooks(self, container):
         lifecycle = container.get("lifecycle") or {}
         ps = lifecycle.get("postStart")
-        return {container["name"]: handles._translate_lifecycle_hook(ps) if ps else None}
+        return {
+            container["name"]: handles._translate_lifecycle_hook(ps) if ps else None
+        }
 
     def test_no_poststart_when_not_defined(self):
         container = _container("c1", "docker://busybox:latest")

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -597,24 +597,55 @@ class TestExpandCommandEnv:
         assert result == ["'$(UNKNOWN)'"]
 
 
-class TestAddMeshDaskHost:
+class TestConfigureMeshDaskWorker:
     def test_adds_mesh_interface_address(self):
         tokens = ["dask-worker", "tls://scheduler:8786", "--nthreads", "1"]
         mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
-        assert handles._add_mesh_dask_host(tokens, mesh) == tokens + [
+        assert handles._configure_mesh_dask_worker(tokens, mesh) == tokens + [
             "--host",
             "10.7.0.2",
+        ]
+
+    def test_adds_worker_contact_address(self):
+        tokens = ["dask-worker", "tls://scheduler:8786"]
+        mesh = """
+ip addr add 10.7.0.2/32 dev $WG_IFACE
+export INTERLINK_MESH_CONTACT_HOST="worker-tunnel.pods-wstunnel.svc.cluster.local"
+"""
+        assert handles._configure_mesh_dask_worker(tokens, mesh) == tokens + [
+            "--host",
+            "10.7.0.2",
+            "--worker-port",
+            "8788",
+            "--contact-address",
+            "tls://worker-tunnel.pods-wstunnel.svc.cluster.local:8788",
         ]
 
     def test_preserves_explicit_host(self):
         tokens = ["dask-worker", "tls://scheduler:8786", "--host", "10.8.0.2"]
         mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
-        assert handles._add_mesh_dask_host(tokens, mesh) == tokens
+        assert handles._configure_mesh_dask_worker(tokens, mesh) == tokens
+
+    def test_preserves_explicit_contact_options(self):
+        tokens = [
+            "dask-worker",
+            "tls://scheduler:8786",
+            "--worker-port",
+            "9000",
+            "--contact-address",
+            "tls://worker.example:9000",
+        ]
+        mesh = """
+ip addr add 10.7.0.2/32 dev $WG_IFACE
+export INTERLINK_MESH_CONTACT_HOST="worker-tunnel.pods-wstunnel.svc.cluster.local"
+"""
+        result = handles._configure_mesh_dask_worker(tokens, mesh)
+        assert result == tokens + ["--host", "10.7.0.2"]
 
     def test_ignores_non_dask_commands(self):
         tokens = ["python", "worker.py"]
         mesh = "ip addr add 10.7.0.2/32 dev $WG_IFACE"
-        assert handles._add_mesh_dask_host(tokens, mesh) == tokens
+        assert handles._configure_mesh_dask_worker(tokens, mesh) == tokens
 
 
 class TestPrepareEnvFile:


### PR DESCRIPTION
The worker command included a placeholder for the worker’s name:

`--name $(DASK_GATEWAY_WORKER_NAME)`

The plugin passed that placeholder directly to Bash. Bash misunderstood and ran the command DASK_GATEWAY_WORKER_NAME, instead of replacing it with the worker’s actual name.
After correcting the name, we found that Dask was also trying to listen on a network address that did not exist inside the worker’s mesh network. This caused the process responsible for starting and monitoring the worker dask nanny plugin to fail with the error

```
OSError: [Errno 99] Cannot assign requested address
RuntimeError: Nanny failed to start.
```

We fixed both problems by replacing the name placeholder before building the command and telling Dask to use the worker’s WireGuard address, 10.7.0.2. The worker then starts with the correct name and can use the mesh tunnel. 