### PR TITLE
fix: remove HTCondor job directories on pod deletion

### DIFF
--- a/handles.py
+++ b/handles.py
@@ -6,6 +6,7 @@ import math
 import os
 import re
 import shlex
+import shutil
 import subprocess
 from datetime import datetime
 
@@ -1375,41 +1376,11 @@ def delete_pod(pod):
     preprocessed = process.read()
     process.close()
 
-    # Remove job directory contents
-    try:
-        os.remove(os.path.join(job_dir, f"{name}-{uid}.jid"))
-    except FileNotFoundError:
-        pass
-    try:
-        os.remove(os.path.join(job_dir, f"{name}-{uid}.sh"))
-    except FileNotFoundError:
-        pass
-    try:
-        os.remove(os.path.join(job_dir, f"{name}-{uid}.jdl"))
-    except FileNotFoundError:
-        pass
-    try:
-        os.remove(os.path.join(job_dir, f"{name}-{uid}_env.env"))
-    except FileNotFoundError:
-        pass
-
-    # Clean up per-container log files transferred back by HTCondor inside job dir.
-    try:
-        with os.scandir(job_dir) as it:
-            for entry in it:
-                if entry.name.startswith(f"{name}-{uid}-") and entry.name.endswith(
-                    ".out"
-                ):
-                    os.remove(entry.path)
-    except OSError as e:
-        logging.warning(f"Could not clean up log files for {name}-{uid}: {e}")
-
-    # Optionally remove the job directory if empty
-    try:
-        os.rmdir(job_dir)
-    except OSError:
-        # Directory not empty or other error — leave it in place
-        pass
+    data_root = os.path.realpath(datarootfolder)
+    job_dir_real = os.path.realpath(job_dir)
+    if not job_dir_real.startswith(data_root + os.sep):
+        raise ValueError(f"Job directory escapes data root: {job_dir!r}")
+    shutil.rmtree(job_dir_real)
 
     return preprocessed
 

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -1416,3 +1416,32 @@ class TestSystemInfoEndpoint:
         data = _json.loads(resp.data)
         assert data["htcondor_connected"] is False
         assert data["status"] == "warning"
+
+
+class TestDeletePod:
+    def test_removes_complete_job_directory(self, tmp_path, monkeypatch):
+        name = "worker"
+        uid = "abc-123"
+        job_dir = tmp_path / f"{name}-{uid}"
+        (job_dir / "secrets" / "credentials").mkdir(parents=True)
+        (job_dir / "log").mkdir()
+        (job_dir / f"{name}-{uid}.jid").write_text("123")
+        (job_dir / "secrets" / "credentials" / "token").write_text("secret")
+        (job_dir / "log" / "job.log").write_text("finished")
+
+        class FakeProcess:
+            def read(self):
+                return "Job 123 removed"
+
+            def close(self):
+                return None
+
+        monkeypatch.setitem(handles.InterLinkConfigInst, "DataRootFolder", str(tmp_path))
+        monkeypatch.setattr(handles.os, "popen", lambda command: FakeProcess())
+
+        result = handles.delete_pod(
+            {"metadata": {"name": name, "uid": uid, "namespace": "default"}}
+        )
+
+        assert result == "Job 123 removed"
+        assert not job_dir.exists()

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -785,9 +785,7 @@ class TestGeneratePreStopTrap:
             {
                 "name": "c1",
                 "image": "busybox:latest",
-                "lifecycle": {
-                    "preStop": {"exec": {"command": ["true"]}}
-                },
+                "lifecycle": {"preStop": {"exec": {"command": ["true"]}}},
             }
         ]
         result = handles.generate_prestop_trap(containers, self._base_metadata())
@@ -846,7 +844,9 @@ class TestGeneratePreStopTrap:
 class TestPreStopTrapInScript:
     """Integration tests: preStop trap is injected into the generated script."""
 
-    def _container_with_prestop(self, name="c1", image="docker://busybox:latest", cmd=None):
+    def _container_with_prestop(
+        self, name="c1", image="docker://busybox:latest", cmd=None
+    ):
         if cmd is None:
             cmd = ["/bin/sh", "-c", "cleanup"]
         return {
@@ -857,9 +857,7 @@ class TestPreStopTrapInScript:
 
     def test_trap_in_script_when_prestop_defined(self):
         container = self._container_with_prestop()
-        prestop_trap = handles.generate_prestop_trap(
-            [container], _fake_metadata()
-        )
+        prestop_trap = handles.generate_prestop_trap([container], _fake_metadata())
         script = _make_script(
             [container],
             [("c1", ["singularity", "exec", "docker://busybox:latest", "sh"])],
@@ -953,7 +951,14 @@ class TestPostStartHelpers:
         assert handles._find_tmp_bind_in_tokens(tokens) == "/host/tmp"
 
     def test_find_tmp_bind_in_comma_spec(self):
-        tokens = ["singularity", "exec", "--bind", "/a:/b,/h/t:/tmp", "docker://img", "sh"]
+        tokens = [
+            "singularity",
+            "exec",
+            "--bind",
+            "/a:/b,/h/t:/tmp",
+            "docker://img",
+            "sh",
+        ]
         assert handles._find_tmp_bind_in_tokens(tokens) == "/h/t"
 
     def test_find_image_docker_prefix(self):
@@ -1067,7 +1072,9 @@ class TestPostStartInScript:
     def _poststart_hooks(self, container):
         lifecycle = container.get("lifecycle") or {}
         ps = lifecycle.get("postStart")
-        return {container["name"]: handles._translate_lifecycle_hook(ps) if ps else None}
+        return {
+            container["name"]: handles._translate_lifecycle_hook(ps) if ps else None
+        }
 
     def test_no_poststart_when_not_defined(self):
         container = _container("c1", "docker://busybox:latest")
@@ -1436,7 +1443,9 @@ class TestDeletePod:
             def close(self):
                 return None
 
-        monkeypatch.setitem(handles.InterLinkConfigInst, "DataRootFolder", str(tmp_path))
+        monkeypatch.setitem(
+            handles.InterLinkConfigInst, "DataRootFolder", str(tmp_path)
+        )
         monkeypatch.setattr(handles.os, "popen", lambda command: FakeProcess())
 
         result = handles.delete_pod(


### PR DESCRIPTION
Deleting a finished job revmoed only a few files before calling os.rmdir() which does not work on non empty directories. changed to run shutil.rmtree on the whole job dir

job_dir_is calculated from the configured datarootfolder combined with the K8s pod’s unique name and UID, then resolved to its absolute path before deletion.